### PR TITLE
Update gcp_variables.tf

### DIFF
--- a/terraform/gcp_variables.tf
+++ b/terraform/gcp_variables.tf
@@ -41,5 +41,5 @@ variable gcp_instance_type {
 
 variable gcp_disk_image {
   description = "Boot disk for gcp_instance_type."
-  default = "projects/debian-cloud/global/images/family/debian-8"
+  default = "projects/debian-cloud/global/images/family/debian-9"
 }


### PR DESCRIPTION
Changed disk_image from 8 to 9 as 8 is no longer supported.