### PR TITLE
Fix Terraform warnings

### DIFF
--- a/terraform/gcp_compute.tf
+++ b/terraform/gcp_compute.tf
@@ -26,12 +26,12 @@ data "google_compute_zones" "available" {
 
 resource "google_compute_instance" "gcp-vm" {
   name         = "gcp-vm-${var.gcp_region}"
-  machine_type = "${var.gcp_instance_type}"
-  zone         = "${data.google_compute_zones.available.names[0]}"
+  machine_type = var.gcp_instance_type
+  zone         = data.google_compute_zones.available.names[0]
 
   boot_disk {
     initialize_params {
-      image = "${var.gcp_disk_image}"
+      image = var.gcp_disk_image
     }
   }
 

--- a/terraform/gcp_variables.tf
+++ b/terraform/gcp_variables.tf
@@ -21,12 +21,12 @@
 
 variable gcp_credentials_file_path {
   description = "Locate the GCP credentials .json file."
-  type = "string"
+  type = string
 }
 
 variable "gcp_project_id" {
   description = "GCP Project ID."
-  type = "string"
+  type = string
 }
 
 variable gcp_region {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,11 +22,11 @@
 provider "google" {
   version = "~> 2.11.0"
 
-  credentials = "${file("${var.gcp_credentials_file_path}")}"
+  credentials = file("${var.gcp_credentials_file_path}")
 
   # Should be able to parse project from credentials file but cannot.
   # Cannot convert string to map and cannot interpolate within variables.
-  project = "${var.gcp_project_id}"
+  project = var.gcp_project_id
 
-  region = "${var.gcp_region}"
+  region = var.gcp_region
 }


### PR DESCRIPTION
When following the Automated Network Deployment: Startup tutorial, running Terraform in the [Deploy with Terraform](https://cloud.google.com/solutions/automated-network-deployment-startup#deploy_with_terraform) section throws some warnings. Warnings include:
 - `Interpolation-only expressions are deprecated`
 - `Quoted type constraints are deprecated`

These don't block running Terraform so it's not a huge deal, but it might be nice to fix.